### PR TITLE
Added support for the Cm_Cache_Backend_Redis

### DIFF
--- a/app/code/community/Hackathon/MageMonitoring/Model/CacheStats/Memcache.php
+++ b/app/code/community/Hackathon/MageMonitoring/Model/CacheStats/Memcache.php
@@ -31,18 +31,22 @@ class Hackathon_MageMonitoring_Model_CacheStats_Memcache implements Hackathon_Ma
     {
         try {
             if ($this->_memCachePool == null && class_exists('Memcache', false)) {
-                $localXml = simplexml_load_file('app/etc/local.xml', null, LIBXML_NOCDATA);
 
-                if ($xr = $localXml->xpath('//cache/memcached/servers/server')) {
+                $cacheConfig = Mage::getConfig()->getNode('global/cache')->asArray();
+
+                if ( $cacheConfig['backend'] == 'memcached' ) {
                     $this->_memCachePool = new Memcache;
-                    foreach ($xr as $server) {
-                        $host = (string)$server->host;
-                        $port = (string)$server->port;
+
+                    foreach( $cacheConfig['memcached']['servers'] as $server ) {
+                        $host = (string)$server['host'];
+                        $port = (string)$server['port'];
                         $this->_memCachePool->addServer($host, $port);
                     }
+
                     $this->_memCacheStats = $this->_memCachePool->getStats();
                 }
             }
+
         } catch (Exception $e) {
             Mage::logException($e);
         }

--- a/app/code/community/Hackathon/MageMonitoring/Model/CacheStats/Redis.php
+++ b/app/code/community/Hackathon/MageMonitoring/Model/CacheStats/Redis.php
@@ -30,17 +30,14 @@ class Hackathon_MageMonitoring_Model_CacheStats_Redis implements Hackathon_MageM
     public function __construct()
     {
         try {
-            $localXml = simplexml_load_file('app/etc/local.xml', null, LIBXML_NOCDATA);
-            $cacheBackend = $localXml->xpath('//cache/backend');
+            $cacheConfig = Mage::getConfig()->getNode('global/cache')->asArray();
 
-            if ((string)$cacheBackend[0] == 'Cm_Cache_Backend_Redis') {
-                if ($backendOptions = $localXml->xpath('//cache/backend_options')) {
-                    $server = (string)$backendOptions[0]->server;
-                    $port   = (int)$backendOptions[0]->port;
+            if ($cacheConfig['backend'] == 'Cm_Cache_Backend_Redis') {
+                $server = $cacheConfig['backend_options']['server'];
+                $port   = $cacheConfig['backend_options']['port'];
 
-                    $this->_redisClient = new Credis_Client($server, $port);
-                    $this->_redisInfo = $this->_redisClient->__call('info', array());
-                }
+                $this->_redisClient = new Credis_Client($server, $port);
+                $this->_redisInfo = $this->_redisClient->__call('info', array());
             }
 
         } catch (Exception $e) {
@@ -50,7 +47,9 @@ class Hackathon_MageMonitoring_Model_CacheStats_Redis implements Hackathon_MageM
 
     public function getId()
     {
-        return $this->_redisInfo['process_id'];
+        $o = array();
+        preg_match("/.+_(.+)\z/", __CLASS__, $o);
+        return strtolower($o[1]);
     }
 
     public function getName()


### PR DESCRIPTION
Might need some refactoring.. maybe we could consider splitting up the
cache interface into 2 types: opcode caching / object caching? Because
now there is some useful information missing. Or alternatively we could
add a generic function which could return a key-value array of
additional information to be printed in the list
