### PR TITLE
fix cron expr

### DIFF
--- a/app/code/community/Hackathon/MageMonitoring/etc/config.xml
+++ b/app/code/community/Hackathon/MageMonitoring/etc/config.xml
@@ -110,7 +110,7 @@
         <jobs>
             <magemonitoring_uberdog>
                 <schedule>
-                    <cron_expr>always</cron_expr>
+                    <cron_expr>* * * * *</cron_expr>
                 </schedule>
                 <run>
                     <model>magemonitoring/watchDog_uberDog::triggerActiveDogs</model>


### PR DESCRIPTION
Looks like "always" is not an allowed cron expression. Switched to the
more standard \* \* \* \* *.

Without this i always get an error during cron schedule generation. (1.7.0.2)
