### PR TITLE
Add compatibility to Magento patch SUPEE-6285 (validating admin ACL)

### DIFF
--- a/app/code/community/Hackathon/MageMonitoring/controllers/Adminhtml/MonitoringController.php
+++ b/app/code/community/Hackathon/MageMonitoring/controllers/Adminhtml/MonitoringController.php
@@ -152,6 +152,6 @@ class Hackathon_MageMonitoring_Adminhtml_MonitoringController extends Mage_Admin
      */
     protected function _isAllowed()
     {
-        return Mage::getSingleton('admin/session')->isAllowed('magemonitoring');
+        return Mage::getSingleton('admin/session')->isAllowed('system/magemonitoring');
     }
 }

--- a/app/code/community/Hackathon/MageMonitoring/controllers/Adminhtml/WidgetAjaxController.php
+++ b/app/code/community/Hackathon/MageMonitoring/controllers/Adminhtml/WidgetAjaxController.php
@@ -262,4 +262,14 @@ class Hackathon_MageMonitoring_Adminhtml_WidgetAjaxController extends Mage_Admin
 
         Mage::getConfig()->reinit();
     }
+
+    /**
+     * Permission check
+     *
+     * @return mixed
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/magemonitoring');
+    }
 }


### PR DESCRIPTION
If you update to Magento 1.9.2.1 and you try to visit System -> Monitoring, you get an access denied because of changes made in SUPEE-6285. This patch will add some validation of the admin ACL in the controllers.